### PR TITLE
Properly render help & error texts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ### 2023-03-07
 * Block `form_help`: Implement our own from parent theme, resolve issue with help class and element type
 * Block `form_row`: Remove bad way of getting help text through `form.vars.attr.help_text`
-* Block `form_row` & `choice_row`: Add `{{- form_errors(form) -}}` & `{{- form_help(form) -}}`
+* Block `form_row`, `choice_row`, `money_row` & `percent_row`: Add `{{- form_errors(form) -}}` & `{{- form_help(form) -}}`
 * Remove all `{{- block('form_errors') -}}` to avoid duplicated error messages
 
 ### 2022-11-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2023-03-07
+* Block `form_help`: Implement our own from parent theme, resolve issue with help class and element type
+* Block `form_row`: Remove bad way of getting help text through `form.vars.attr.help_text`
+* Block `form_row` & `choice_row`: Add `{{- form_errors(form) -}}` & `{{- form_help(form) -}}`
+* Remove all `{{- block('form_errors') -}}` to avoid duplicated error messages
+
 ### 2022-11-14
 * Block `choice_widget_dropdown`: Removed inline-styles and added it to docs
 

--- a/views/Form/bulma_layout.html.twig
+++ b/views/Form/bulma_layout.html.twig
@@ -23,7 +23,6 @@
                     <i class="fa fa-{{ attribute(widget_icon, 'icon')|default('') -}}"></i>
                 </div>
             {%- endif -%}
-            {{- block('form_errors') -}}
         </div>
     {%- endif -%}
 {%- endblock form_widget_simple %}
@@ -34,7 +33,6 @@
         <div class="{{ ('select ' ~ (multiple ? 'is-multiple ') ~ classes|join(' '))|trim }}">
             {{- parent() -}}
         </div>
-        {{- block('form_errors') -}}
     </div>
 {%- endblock choice_widget_collapsed -%}
 
@@ -59,7 +57,6 @@
                     translation_domain: choice_translation_domain,
                 }) -}}
             {%- endfor -%}
-            {{- block('form_errors') -}}
         </div>
 
         {%- if inline_choice|default(false) == true -%}
@@ -126,14 +123,12 @@
             {%- endfor -%}
         </div>
     </div>
-    {{- block('form_errors') -}}
 {%- endblock -%}
 
 {%- block textarea_widget -%}
     <div {{ block('form_widget_container_attributes') }}>
         {%- set attr = attr|merge({class: (attr.class|default('') ~ ' textarea')|trim}) -%}
         <textarea {{ block('widget_attributes') }}>{{ value }}</textarea>
-        {{- block('form_errors') -}}
     </div>
 {%- endblock textarea_widget -%}
 
@@ -159,7 +154,6 @@
         <div {{ block('widget_container_attributes') }}>
             {{- form_widget(form.date) -}}
             {{- form_widget(form.time) -}}
-            {{- form_errors(form) -}}
             {{- form_errors(form.date) -}}
             {{- form_errors(form.time) -}}
         </div>
@@ -257,10 +251,32 @@
             {% endif %}
         {% endif %}
         </label>
-        {{- block('form_errors') -}}
         {%- if not inline_choice|default(false) %}</div>{% endif -%}
     {% endif %}
 {% endblock checkbox_radio_label %}
+
+{# Help #}
+
+{%- block form_help -%}
+    {%- if help is not empty -%}
+        {%- set help_attr = help_attr|merge({class: ('help ' ~ help_attr.class|default(''))|trim}) -%}
+        <div id="{{ id }}_help"{%- with { attr: help_attr } -%}{{- block('attributes') -}}{%- endwith -%}>
+            {%- if translation_domain is same as(false) -%}
+                {%- if help_html is same as(false) -%}
+                    {{- help -}}
+                {%- else -%}
+                    {{- help|raw -}}
+                {%- endif -%}
+            {%- else -%}
+                {%- if help_html is same as(false) -%}
+                    {{- help|trans(help_translation_parameters, translation_domain) -}}
+                {%- else -%}
+                    {{- help|trans(help_translation_parameters, translation_domain)|raw -}}
+                {%- endif -%}
+            {%- endif -%}
+        </div>
+    {%- endif -%}
+{%- endblock -%}
 
 {# Rows #}
 
@@ -268,9 +284,8 @@
     <div class="field">
         {{- form_label(form) -}}
         {{- form_widget(form) -}}
-        {%- if form.vars.attr.help_text is defined -%}
-            <p class="help">{{ form.vars.attr.help_text }}</p>
-        {%- endif -%}
+        {{- form_errors(form) -}}
+        {{- form_help(form) -}}
     </div>
 {%- endblock form_row -%}
 
@@ -281,6 +296,8 @@
             <div class="dropdown">
                 {{- form_widget(form) -}}
             </div>
+            {{- form_errors(form) -}}
+            {{- form_help(form) -}}
         </div>
     {%- else -%}
         {{- block('form_row') -}}

--- a/views/Form/bulma_layout.html.twig
+++ b/views/Form/bulma_layout.html.twig
@@ -307,11 +307,15 @@
 {%- block money_row -%}
     {{- form_label(form) -}}
     {{- block('form_widget_simple') -}}
+    {{- form_errors(form) -}}
+    {{- form_help(form) -}}
 {%- endblock money_row -%}
 
 {%- block percent_row -%}
     {{- form_label(form) -}}
     {{- block('form_widget_simple') -}}
+    {{- form_errors(form) -}}
+    {{- form_help(form) -}}
 {%- endblock percent_row -%}
 
 {# Errors #}


### PR DESCRIPTION
The last PR that was merged solved some of the issues with help texts but this resolves all.
And any issues related to error texts not displaying properly or duplication as well.

All changes are added to the changelog, and they are as listed below:

* Block `form_help`: Implement our own from parent theme, resolve issue with help class and element type
* Block `form_row`: Remove bad way of getting help text through `form.vars.attr.help_text`
* Block `form_row` & `choice_row`: Add `{{- form_errors(form) -}}` & `{{- form_help(form) -}}`
* Remove all `{{- block('form_errors') -}}` to avoid duplicated error messages